### PR TITLE
Import `Id` struct from the `bxcan` crate

### DIFF
--- a/src/id.rs
+++ b/src/id.rs
@@ -1,0 +1,103 @@
+//! CAN Identifiers.
+
+/// Standard 11-bit CAN Identifier (`0..=0x7FF`).
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub struct StandardId(u16);
+
+impl StandardId {
+    /// CAN ID `0`, the highest priority.
+    pub const ZERO: Self = Self(0);
+
+    /// CAN ID `0x7FF`, the lowest priority.
+    pub const MAX: Self = Self(0x7FF);
+
+    /// Tries to create a `StandardId` from a raw 16-bit integer.
+    ///
+    /// This will return `None` if `raw` is out of range of an 11-bit integer (`> 0x7FF`).
+    #[inline]
+    pub const fn new(raw: u16) -> Option<Self> {
+        if raw <= 0x7FF {
+            Some(Self(raw))
+        } else {
+            None
+        }
+    }
+
+    /// Creates a new `StandardId` without checking if it is inside the valid range.
+    #[inline]
+    pub const unsafe fn new_unchecked(raw: u16) -> Self {
+        Self(raw)
+    }
+
+    /// Returns this CAN Identifier as a raw 16-bit integer.
+    #[inline]
+    pub fn as_raw(&self) -> u16 {
+        self.0
+    }
+}
+
+/// Extended 29-bit CAN Identifier (`0..=1FFF_FFFF`).
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub struct ExtendedId(u32);
+
+impl ExtendedId {
+    /// CAN ID `0`, the highest priority.
+    pub const ZERO: Self = Self(0);
+
+    /// CAN ID `0x1FFFFFFF`, the lowest priority.
+    pub const MAX: Self = Self(0x1FFF_FFFF);
+
+    /// Tries to create a `ExtendedId` from a raw 32-bit integer.
+    ///
+    /// This will return `None` if `raw` is out of range of an 29-bit integer (`> 0x1FFF_FFFF`).
+    #[inline]
+    pub const fn new(raw: u32) -> Option<Self> {
+        if raw <= 0x1FFF_FFFF {
+            Some(Self(raw))
+        } else {
+            None
+        }
+    }
+
+    /// Creates a new `ExtendedId` without checking if it is inside the valid range.
+    #[inline]
+    pub const unsafe fn new_unchecked(raw: u32) -> Self {
+        Self(raw)
+    }
+
+    /// Returns this CAN Identifier as a raw 32-bit integer.
+    #[inline]
+    pub fn as_raw(&self) -> u32 {
+        self.0
+    }
+
+    /// Returns the Base ID part of this extended identifier.
+    pub fn standard_id(&self) -> StandardId {
+        // ID-28 to ID-18
+        StandardId((self.0 >> 18) as u16)
+    }
+}
+
+/// A CAN Identifier (standard or extended).
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum Id {
+    /// Standard 11-bit Identifier (`0..=0x7FF`).
+    Standard(StandardId),
+
+    /// Extended 29-bit Identifier (`0..=0x1FFF_FFFF`).
+    Extended(ExtendedId),
+}
+
+impl From<StandardId> for Id {
+    #[inline]
+    fn from(id: StandardId) -> Self {
+        Id::Standard(id)
+    }
+}
+
+impl From<ExtendedId> for Id {
+    #[inline]
+    fn from(id: ExtendedId) -> Self {
+        Id::Extended(id)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,99 +3,19 @@
 
 pub mod blocking;
 
-/// Standard 11bit Identifier (0..=0x7FF)
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
-pub struct StandardId(u16);
+mod id;
 
-impl StandardId {
-    /// Creates a new standard identifier.
-    pub fn new(id: u16) -> Result<StandardId, ()> {
-        if id <= 0x7FF {
-            Ok(StandardId(id))
-        } else {
-            Err(())
-        }
-    }
-}
-
-impl core::convert::From<StandardId> for u16 {
-    fn from(id: StandardId) -> u16 {
-        id.0
-    }
-}
-
-impl core::convert::From<StandardId> for u32 {
-    fn from(id: StandardId) -> u32 {
-        id.0 as u32
-    }
-}
-
-impl ExtendedId {
-    /// Creates a new extended identifier.
-    pub fn new(id: u32) -> Result<ExtendedId, ()> {
-        if id <= 0x1FFF_FFFF {
-            Ok(ExtendedId(id))
-        } else {
-            Err(())
-        }
-    }
-}
-
-impl core::convert::From<ExtendedId> for u32 {
-    fn from(id: ExtendedId) -> u32 {
-        id.0
-    }
-}
-
-/// Extended 29bit Identifier (0..=0x1FFF_FFFF)
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
-pub struct ExtendedId(u32);
-
-/// CAN Identifier
-///
-/// The variants are wrapped in newtypes so they can only be costructed with valid values.
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
-pub enum Id {
-    /// Standard 11bit Identifier (0..=0x7FF)
-    Standard(StandardId),
-
-    /// Extended 29bit Identifier (0..=0x1FFF_FFFF)
-    Extended(ExtendedId),
-}
-
-impl Id {
-    /// Creates a new standard identifier.
-    pub fn new_standard(id: u16) -> Result<Id, ()> {
-        Ok(StandardId::new(id)?.into())
-    }
-
-    /// Creates a new extended identifier.
-    pub fn new_extended(id: u32) -> Result<Id, ()> {
-        Ok(ExtendedId::new(id)?.into())
-    }
-}
-
-impl core::convert::From<StandardId> for Id {
-    fn from(id: StandardId) -> Id {
-        Id::Standard(id)
-    }
-}
-
-impl core::convert::From<ExtendedId> for Id {
-    fn from(id: ExtendedId) -> Id {
-        Id::Extended(id)
-    }
-}
+pub use id::*;
 
 /// A CAN2.0 Frame
 pub trait Frame: Sized {
     /// Creates a new frame.
     /// Returns an error when the data slice is too long.
-    fn new(id: Id, data: &[u8]) -> Result<Self, ()>;
+    fn new(id: impl Into<Id>, data: &[u8]) -> Result<Self, ()>;
 
     /// Creates a new remote frame (RTR bit set).
     /// Returns an error when the data length code (DLC) is not valid.
-    fn new_remote(id: Id, dlc: usize) -> Result<Self, ()>;
+    fn new_remote(id: impl Into<Id>, dlc: usize) -> Result<Self, ()>;
 
     /// Returns true if this frame is a extended frame.
     fn is_extended(&self) -> bool;


### PR DESCRIPTION
Its a superset of the current `Id` with minor API changes. Fully device independent still.